### PR TITLE
init project

### DIFF
--- a/envschema/__init__.py
+++ b/envschema/__init__.py
@@ -1,0 +1,31 @@
+"""envschema - минималистичная библиотека для работы с переменными окружения.
+
+Типобезопасная загрузка, кастинг и валидация environment variables
+на основе аннотаций типов.
+
+Пример использования:
+    >>> from envschema import EnvSchema, Field
+    >>> 
+    >>> class Settings(EnvSchema):
+    ...     port: int
+    ...     debug: bool = Field(default=False)
+    ...     database_url: str = Field(env="DATABASE_URL")
+    >>> 
+    >>> settings = Settings.load()
+    >>> print(settings.port)
+"""
+
+from .schema import EnvSchema
+from .field import Field
+from .errors import EnvSchemaError, ValidationError
+from .casters import register_caster
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "EnvSchema",
+    "Field",
+    "EnvSchemaError",
+    "ValidationError",
+    "register_caster",
+]

--- a/envschema/casters.py
+++ b/envschema/casters.py
@@ -1,0 +1,227 @@
+import json
+from typing import Any, Callable, TypeVar, get_args, get_origin
+
+
+T = TypeVar('T')
+CasterFunc = Callable[[str], Any]
+
+
+def cast_str(value: str) -> str:
+    """Кастит значение в строку.
+    
+    Args:
+        value: Строковое значение из окружения
+        
+    Returns:
+        Исходная строка без изменений
+    """
+    return value
+
+
+def cast_int(value: str) -> int:
+    """Кастит значение в целое число.
+    
+    Args:
+        value: Строковое значение из окружения
+        
+    Returns:
+        Целое число
+        
+    Raises:
+        ValueError: Если значение невозможно преобразовать в int
+    """
+    try:
+        return int(value)
+    except ValueError:
+        raise ValueError(f"cannot cast '{value}' to int")
+
+
+def cast_float(value: str) -> float:
+    """Кастит значение в число с плавающей точкой.
+    
+    Args:
+        value: Строковое значение из окружения
+        
+    Returns:
+        Число с плавающей точкой
+        
+    Raises:
+        ValueError: Если значение невозможно преобразовать в float
+    """
+    try:
+        return float(value)
+    except ValueError:
+        raise ValueError(f"cannot cast '{value}' to float")
+
+
+def cast_bool(value: str) -> bool:
+    """Кастит значение в булево значение.
+    
+    Поддерживаемые значения:
+    - True: "true", "yes", "1", "on" (регистронезависимо)
+    - False: "false", "no", "0", "off" (регистронезависимо)
+    
+    Args:
+        value: Строковое значение из окружения
+        
+    Returns:
+        Булево значение
+        
+    Raises:
+        ValueError: Если значение не распознано как bool
+    """
+    normalized = value.lower().strip()
+    
+    if normalized in ("true", "yes", "1", "on"):
+        return True
+    elif normalized in ("false", "no", "0", "off"):
+        return False
+    else:
+        raise ValueError(
+            f"invalid boolean value '{value}' "
+            f"(expected: true/false/yes/no/1/0/on/off)"
+        )
+
+
+def cast_list(value: str, item_type: type = str) -> list:
+    """Кастит значение в список.
+    
+    Автоматически определяет формат:
+    - Если строка выглядит как JSON массив → парсит как JSON
+    - Иначе → парсит как CSV (разделитель: запятая)
+    
+    Args:
+        value: Строковое значение из окружения
+        item_type: Тип элементов списка (по умолчанию str)
+        
+    Returns:
+        Список элементов указанного типа
+        
+    Raises:
+        ValueError: Если значение невозможно распарсить
+    """
+    stripped = value.strip()
+    
+    # Проверяем, выглядит ли как JSON массив
+    if stripped.startswith('[') and stripped.endswith(']'):
+        try:
+            parsed = json.loads(stripped)
+            if not isinstance(parsed, list):
+                raise ValueError(f"expected JSON array, got {type(parsed)}")
+            
+            # Кастим элементы в нужный тип
+            if item_type != str:
+                caster = _get_caster_for_type(item_type)
+                return [caster(str(item)) for item in parsed]
+            return parsed
+            
+        except json.JSONDecodeError as e:
+            raise ValueError(f"invalid JSON array: {e}")
+    
+    # Парсим как CSV
+    if not stripped:
+        return []
+    
+    items = [item.strip() for item in stripped.split(',')]
+    
+    # Кастим элементы в нужный тип
+    if item_type != str:
+        caster = _get_caster_for_type(item_type)
+        try:
+            return [caster(item) for item in items]
+        except ValueError as e:
+            raise ValueError(f"cannot cast list items to {item_type.__name__}: {e}")
+    
+    return items
+
+
+def cast_dict(value: str) -> dict:
+    """Кастит значение в словарь через JSON.
+    
+    Args:
+        value: Строковое значение из окружения (JSON формат)
+        
+    Returns:
+        Словарь
+        
+    Raises:
+        ValueError: Если значение невозможно распарсить как JSON объект
+    """
+    try:
+        parsed = json.loads(value)
+        if not isinstance(parsed, dict):
+            raise ValueError(f"expected JSON object, got {type(parsed).__name__}")
+        return parsed
+    except json.JSONDecodeError as e:
+        raise ValueError(f"invalid JSON object: {e}")
+
+
+# Реестр кастеров для базовых типов
+_CASTERS: dict[type, CasterFunc] = {
+    str: cast_str,
+    int: cast_int,
+    float: cast_float,
+    bool: cast_bool,
+    dict: cast_dict,
+}
+
+
+def register_caster(type_: type, caster: CasterFunc) -> None:
+    """Регистрирует кастомный кастер для типа.
+    
+    Args:
+        type_: Тип данных
+        caster: Функция кастинга (str -> type_)
+        
+    Example:
+        >>> def cast_timedelta(value: str) -> timedelta:
+        ...     return timedelta(seconds=int(value))
+        >>> register_caster(timedelta, cast_timedelta)
+    """
+    _CASTERS[type_] = caster
+
+
+def _get_caster_for_type(type_: type) -> CasterFunc:
+    """Получает функцию кастинга для типа.
+    
+    Args:
+        type_: Тип данных
+        
+    Returns:
+        Функция кастинга
+        
+    Raises:
+        ValueError: Если кастер для типа не найден
+    """
+    if type_ in _CASTERS:
+        return _CASTERS[type_]
+    
+    raise ValueError(f"no caster registered for type {type_}")
+
+
+def cast_value(value: str, type_: type) -> Any:
+    """Кастит значение в указанный тип.
+    
+    Поддерживает базовые типы и list[T].
+    
+    Args:
+        value: Строковое значение из окружения
+        type_: Целевой тип данных
+        
+    Returns:
+        Значение указанного типа
+        
+    Raises:
+        ValueError: Если кастинг невозможен
+    """
+    origin = get_origin(type_)
+    
+    # Обработка list[T]
+    if origin is list:
+        args = get_args(type_)
+        item_type = args[0] if args else str
+        return cast_list(value, item_type)
+    
+    # Обработка базовых типов
+    caster = _get_caster_for_type(type_)
+    return caster(value)

--- a/envschema/errors.py
+++ b/envschema/errors.py
@@ -1,0 +1,116 @@
+from typing import Any, Optional
+
+
+class ValidationError:
+    """Ошибка валидации одного поля.
+    
+    Attributes:
+        field_name: Имя поля в схеме
+        env_var: Имя переменной окружения
+        message: Описание ошибки
+        value: Значение, которое не прошло валидацию (если есть)
+        expected_type: Ожидаемый тип данных (если применимо)
+    """
+    
+    def __init__(
+        self,
+        field_name: str,
+        env_var: str,
+        message: str,
+        value: Optional[Any] = None,
+        expected_type: Optional[str] = None,
+    ) -> None:
+        """Инициализирует ошибку валидации.
+        
+        Args:
+            field_name: Имя поля в схеме
+            env_var: Имя переменной окружения
+            message: Описание ошибки
+            value: Значение, которое не прошло валидацию
+            expected_type: Ожидаемый тип данных
+        """
+        self.field_name = field_name
+        self.env_var = env_var
+        self.message = message
+        self.value = value
+        self.expected_type = expected_type
+    
+    def format(self) -> str:
+        """Форматирует ошибку в читаемую строку.
+        
+        Returns:
+            Отформатированное сообщение об ошибке
+        """
+        msg = f"{self.env_var}: {self.message}"
+        
+        if self.expected_type:
+            msg += f" (expected type: {self.expected_type})"
+        
+        if self.value is not None:
+            value_repr = repr(self.value)
+            if len(value_repr) > 50:
+                value_repr = value_repr[:47] + "..."
+            msg += f" [got: {value_repr}]"
+        
+        return msg
+    
+    def __repr__(self) -> str:
+        """Возвращает строковое представление ошибки.
+        
+        Returns:
+            Строковое представление для отладки
+        """
+        return (
+            f"ValidationError(field={self.field_name!r}, "
+            f"env_var={self.env_var!r}, message={self.message!r})"
+        )
+
+
+class EnvSchemaError(Exception):
+    """Исключение при загрузке и валидации схемы окружения.
+    
+    Агрегирует множественные ошибки валидации и форматирует их
+    в понятное сообщение.
+    
+    Attributes:
+        errors: Список ошибок валидации
+    """
+    
+    def __init__(self, errors: list[ValidationError]) -> None:
+        """Инициализирует исключение с набором ошибок.
+        
+        Args:
+            errors: Список ошибок валидации
+        """
+        self.errors = errors
+        message = self._format_errors()
+        super().__init__(message)
+    
+    def _format_errors(self) -> str:
+        """Форматирует все ошибки в единое сообщение.
+        
+        Returns:
+            Отформатированное сообщение со всеми ошибками
+        """
+        if not self.errors:
+            return "Unknown environment schema error"
+        
+        error_count = len(self.errors)
+        plural = "s" if error_count > 1 else ""
+        
+        lines = [
+            f"Failed to load environment variables ({error_count} error{plural}):"
+        ]
+        
+        for error in self.errors:
+            lines.append(f"  * {error.format()}")
+        
+        return "\n".join(lines)
+    
+    def __repr__(self) -> str:
+        """Возвращает строковое представление исключения.
+        
+        Returns:
+            Строковое представление для отладки
+        """
+        return f"EnvSchemaError(errors={self.errors!r})"

--- a/envschema/field.py
+++ b/envschema/field.py
@@ -1,0 +1,154 @@
+"""Модуль дескриптора Field для описания полей схемы."""
+
+from typing import Any, Optional
+
+
+# Sentinel для отсутствия значения по умолчанию
+_MISSING = object()
+
+
+class Field:
+    """Дескриптор для описания поля схемы окружения.
+    
+    Attributes:
+        default: Значение по умолчанию (если не обязательное)
+        env: Кастомное имя переменной окружения
+        description: Описание поля для документации
+        prefix: Префикс для вложенных структур
+    """
+    
+    def __init__(
+        self,
+        default: Any = _MISSING,
+        env: Optional[str] = None,
+        description: Optional[str] = None,
+        prefix: Optional[str] = None,
+    ) -> None:
+        """Инициализирует дескриптор поля.
+        
+        Args:
+            default: Значение по умолчанию. Если не указано, поле обязательное
+            env: Кастомное имя переменной окружения
+            description: Описание поля для автогенерации документации
+            prefix: Префикс для вложенных структур (например, "DB_")
+        """
+        self.default = default
+        self.env = env
+        self.description = description
+        self.prefix = prefix
+        self._name: Optional[str] = None
+    
+    def __set_name__(self, owner: type, name: str) -> None:
+        """Вызывается при определении дескриптора в классе.
+        
+        Args:
+            owner: Класс-владелец
+            name: Имя атрибута в классе
+        """
+        self._name = name
+    
+    @property
+    def name(self) -> str:
+        """Возвращает имя поля.
+        
+        Returns:
+            Имя поля в схеме
+            
+        Raises:
+            RuntimeError: Если дескриптор не был правильно инициализирован
+        """
+        if self._name is None:
+            raise RuntimeError(
+                "Field descriptor was not properly initialized. "
+                "Make sure it's used as a class attribute."
+            )
+        return self._name
+    
+    def get_env_name(self, prefix: str = "") -> str:
+        """Получает имя переменной окружения для поля.
+        
+        Применяет префикс (если есть) и преобразует в UPPER_CASE.
+        
+        Args:
+            prefix: Префикс схемы (если поле находится во вложенной структуре)
+            
+        Returns:
+            Имя переменной окружения (UPPER_CASE)
+        """
+        if self.env:
+            return self.env
+        
+        # Преобразуем имя поля в UPPER_CASE
+        env_name = self.name.upper()
+        
+        # Добавляем префикс Field'а (для вложенных структур)
+        if self.prefix:
+            env_name = f"{self.prefix}{env_name}"
+        
+        # Добавляем префикс схемы
+        if prefix:
+            env_name = f"{prefix}{env_name}"
+        
+        return env_name
+    
+    def has_default(self) -> bool:
+        """Проверяет, есть ли у поля значение по умолчанию.
+        
+        Returns:
+            True если поле имеет значение по умолчанию, False если обязательное
+        """
+        return self.default is not _MISSING
+    
+    def get_default(self) -> Any:
+        """Получает значение по умолчанию.
+        
+        Returns:
+            Значение по умолчанию
+            
+        Raises:
+            RuntimeError: Если поле не имеет значения по умолчанию
+        """
+        if not self.has_default():
+            raise RuntimeError(f"Field '{self.name}' has no default value")
+        return self.default
+    
+    def __repr__(self) -> str:
+        """Возвращает строковое представление дескриптора.
+        
+        Returns:
+            Строковое представление для отладки
+        """
+        parts = []
+        
+        if self.has_default():
+            parts.append(f"default={self.default!r}")
+        
+        if self.env:
+            parts.append(f"env={self.env!r}")
+        
+        if self.description:
+            parts.append(f"description={self.description!r}")
+        
+        if self.prefix:
+            parts.append(f"prefix={self.prefix!r}")
+        
+        args = ", ".join(parts) if parts else ""
+        return f"Field({args})"
+
+
+def field_from_default(default_value: Any) -> Field:
+    """Создает Field из значения по умолчанию.
+    
+    Используется для автоматического создания Field'ов из простых дефолтов.
+    
+    Args:
+        default_value: Значение по умолчанию
+        
+    Returns:
+        Field с указанным значением по умолчанию
+        
+    Example:
+        >>> class Settings(EnvSchema):
+        ...     debug: bool = False  # Автоматически → Field(default=False)
+    """
+    return Field(default=default_value)

--- a/envschema/schema.py
+++ b/envschema/schema.py
@@ -1,0 +1,211 @@
+import os
+from typing import Any, Optional, get_type_hints
+
+from .errors import EnvSchemaError, ValidationError
+from .field import Field, field_from_default, _MISSING
+from .casters import cast_value
+
+
+class EnvSchemaMeta(type):
+    """Метакласс для EnvSchema.
+    
+    Обрабатывает аннотации типов и создает Field дескрипторы.
+    """
+    
+    def __new__(
+        mcs,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        **kwargs: Any
+    ) -> type:
+        """Создает новый класс схемы.
+        
+        Args:
+            name: Имя класса
+            bases: Базовые классы
+            namespace: Пространство имен класса
+            **kwargs: Дополнительные аргументы
+            
+        Returns:
+            Новый класс схемы
+        """
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        
+        # Не обрабатываем базовый класс EnvSchema
+        if name == 'EnvSchema':
+            return cls
+        
+        # Получаем аннотации типов
+        annotations = namespace.get('__annotations__', {})
+        
+        # Обрабатываем каждое поле
+        for field_name, field_type in annotations.items():
+            # Проверяем, есть ли уже Field дескриптор
+            field_value = namespace.get(field_name, _MISSING)
+            
+            if isinstance(field_value, Field):
+                # Уже Field, оставляем как есть
+                field_obj = field_value
+            elif field_value is not _MISSING:
+                # Простое значение по умолчанию → создаем Field
+                field_obj = field_from_default(field_value)
+                setattr(cls, field_name, field_obj)
+            else:
+                # Обязательное поле без значения → создаем Field без default
+                field_obj = Field()
+                setattr(cls, field_name, field_obj)
+        
+        return cls
+
+
+class EnvSchema(metaclass=EnvSchemaMeta):
+    """Базовый класс для схем переменных окружения.
+    
+    Пример использования:
+        >>> class Settings(EnvSchema):
+        ...     port: int
+        ...     debug: bool = False
+        ...     api_key: str = Field(env="SECRET_API_KEY")
+        >>> settings = Settings.load()
+    """
+    
+    def __init__(self, **values: Any) -> None:
+        """Инициализирует экземпляр схемы с значениями.
+        
+        Args:
+            **values: Значения полей
+        """
+        for key, value in values.items():
+            setattr(self, key, value)
+    
+    @classmethod
+    def _get_fields(cls) -> dict[str, tuple[Field, type]]:
+        """Получает все поля схемы с их типами.
+        
+        Returns:
+            Словарь {имя_поля: (Field, тип)}
+        """
+        fields = {}
+        type_hints = get_type_hints(cls)
+        
+        for attr_name in dir(cls):
+            attr_value = getattr(cls, attr_name)
+            
+            if isinstance(attr_value, Field):
+                field_type = type_hints.get(attr_name, str)
+                fields[attr_name] = (attr_value, field_type)
+        
+        return fields
+    
+    @classmethod
+    def load(
+        cls,
+        env: Optional[dict[str, str]] = None,
+        prefix: str = "",
+    ) -> "EnvSchema":
+        """Загружает и валидирует схему из переменных окружения.
+        
+        Args:
+            env: Словарь переменных окружения (по умолчанию os.environ)
+            prefix: Префикс для всех переменных схемы
+            
+        Returns:
+            Экземпляр схемы со значениями из окружения
+            
+        Raises:
+            EnvSchemaError: Если валидация не прошла
+        """
+        if env is None:
+            env = dict(os.environ)
+        
+        fields = cls._get_fields()
+        errors: list[ValidationError] = []
+        values: dict[str, Any] = {}
+        
+        for field_name, (field, field_type) in fields.items():
+            env_name = field.get_env_name(prefix)
+            
+            try:
+                value = cls._load_field(
+                    field=field,
+                    field_name=field_name,
+                    field_type=field_type,
+                    env_name=env_name,
+                    env=env,
+                )
+                values[field_name] = value
+                
+            except ValidationError as e:
+                errors.append(e)
+        
+        if errors:
+            raise EnvSchemaError(errors)
+        
+        return cls(**values)
+    
+    @classmethod
+    def _load_field(
+        cls,
+        field: Field,
+        field_name: str,
+        field_type: type,
+        env_name: str,
+        env: dict[str, str],
+    ) -> Any:
+        """Загружает и валидирует одно поле.
+        
+        Args:
+            field: Дескриптор поля
+            field_name: Имя поля в схеме
+            field_type: Тип поля
+            env_name: Имя переменной окружения
+            env: Словарь переменных окружения
+            
+        Returns:
+            Значение поля
+            
+        Raises:
+            ValidationError: Если валидация не прошла
+        """
+        raw_value = env.get(env_name)
+        
+        # Проверяем наличие значения
+        if raw_value is None:
+            if field.has_default():
+                return field.get_default()
+            else:
+                raise ValidationError(
+                    field_name=field_name,
+                    env_var=env_name,
+                    message="missing required environment variable",
+                    expected_type=field_type.__name__,
+                )
+        
+        # Кастим значение в нужный тип
+        try:
+            return cast_value(raw_value, field_type)
+        except ValueError as e:
+            raise ValidationError(
+                field_name=field_name,
+                env_var=env_name,
+                message=str(e),
+                value=raw_value,
+                expected_type=field_type.__name__,
+            )
+    
+    def __repr__(self) -> str:
+        """Возвращает строковое представление схемы.
+        
+        Returns:
+            Строковое представление для отладки
+        """
+        fields = self._get_fields()
+        field_values = []
+        
+        for field_name in fields.keys():
+            value = getattr(self, field_name, None)
+            field_values.append(f"{field_name}={value!r}")
+        
+        fields_str = ", ".join(field_values)
+        return f"{self.__class__.__name__}({fields_str})"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `envschema` core with `EnvSchema`, `Field`, casting, and validation/errors for loading environment variables from annotations.
> 
> - **Core**:
>   - Add `EnvSchema` with metaclass `EnvSchemaMeta` to auto-create `Field` descriptors from type annotations and defaults (`envschema/schema.py`).
>   - Implement loading from `os.environ` with prefix support, type casting, and aggregated validation (`EnvSchema.load`).
> - **Fields**:
>   - Add `Field` descriptor with defaults, custom `env` names, descriptions, and per-field `prefix`; includes helpers like `field_from_default` (`envschema/field.py`).
> - **Casting**:
>   - Implement casters for `str`, `int`, `float`, `bool`, `dict`, and `list[T]` (CSV or JSON) plus registry and `register_caster` (`envschema/casters.py`).
> - **Errors**:
>   - Add `ValidationError` and `EnvSchemaError` to collect and format failures (`envschema/errors.py`).
> - **Public API**:
>   - Export `EnvSchema`, `Field`, `EnvSchemaError`, `ValidationError`, and `register_caster` in `envschema/__init__.py` with version `0.1.0`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 217b549f0023af9eaec0ffee10861be0008ba180. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->