### PR TITLE
Add support for loading from .env files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,13 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.4
     hooks:
-      - id: ruff-format
       - id: ruff
+        args:
+          - --fix
+      - id: ruff-format

--- a/envschema/__init__.py
+++ b/envschema/__init__.py
@@ -18,6 +18,7 @@
 from .casters import register_caster
 from .errors import EnvSchemaError, ValidationError
 from .field import Field
+from .loader import load_dotenv, load_env_with_dotenv
 from .schema import EnvSchema
 
 __version__ = "0.1.0"
@@ -28,4 +29,6 @@ __all__ = [
     "EnvSchemaError",
     "ValidationError",
     "register_caster",
+    "load_dotenv",
+    "load_env_with_dotenv",
 ]

--- a/envschema/loader.py
+++ b/envschema/loader.py
@@ -5,7 +5,8 @@ from pathlib import Path
 def load_dotenv(dotenv_path: str | Path | bool) -> dict[str, str]:
     """Загружает переменные из .env файла.
 
-    Использует python-dotenv если доступен, иначе выдает понятную ошибку.
+    При dotenv_path=True выполняет рекурсивный поиск .env файла вверх
+    по дереву каталогов от текущей рабочей директории до корня проекта.
 
     Args:
         dotenv_path: Путь к .env файлу, True для автопоиска, или False
@@ -19,6 +20,9 @@ def load_dotenv(dotenv_path: str | Path | bool) -> dict[str, str]:
     """
     try:
         from dotenv import dotenv_values  # type: ignore[import-not-found]
+        from dotenv import (
+            find_dotenv as find_dotenv_util,  # type: ignore[import-not-found]
+        )
     except ImportError as e:
         raise ImportError(
             "python-dotenv is required for .env file support. "
@@ -28,7 +32,12 @@ def load_dotenv(dotenv_path: str | Path | bool) -> dict[str, str]:
 
     if isinstance(dotenv_path, bool):
         if dotenv_path:
-            file_path = Path.cwd() / ".env"
+            found_path = find_dotenv_util(usecwd=True)
+            if not found_path:
+                raise FileNotFoundError(
+                    ".env file not found in current or parent directories"
+                )
+            file_path = Path(found_path)
         else:
             return {}
     else:
@@ -38,7 +47,6 @@ def load_dotenv(dotenv_path: str | Path | bool) -> dict[str, str]:
         raise FileNotFoundError(f".env file not found: {file_path}")
 
     env_vars = dotenv_values(str(file_path))
-
     return {k: v for k, v in env_vars.items() if v is not None}
 
 

--- a/envschema/loader.py
+++ b/envschema/loader.py
@@ -1,0 +1,99 @@
+import os
+from pathlib import Path
+
+
+def load_dotenv(dotenv_path: str | Path | bool) -> dict[str, str]:
+    """Загружает переменные из .env файла.
+
+    Использует python-dotenv если доступен, иначе выдает понятную ошибку.
+
+    Args:
+        dotenv_path: Путь к .env файлу, True для автопоиска, или False
+
+    Returns:
+        Словарь переменных окружения из файла
+
+    Raises:
+        ImportError: Если python-dotenv не установлен
+        FileNotFoundError: Если указанный файл не существует
+    """
+    try:
+        from dotenv import dotenv_values  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "python-dotenv is required for .env file support. "
+            "Install it with: pip install envschema[dotenv] "
+            "or pip install python-dotenv"
+        ) from e
+
+    if isinstance(dotenv_path, bool):
+        if dotenv_path:
+            file_path = Path.cwd() / ".env"
+        else:
+            return {}
+    else:
+        file_path = Path(dotenv_path)
+
+    if not file_path.exists():
+        raise FileNotFoundError(f".env file not found: {file_path}")
+
+    env_vars = dotenv_values(str(file_path))
+
+    return {k: v for k, v in env_vars.items() if v is not None}
+
+
+def merge_env_sources(
+    dotenv_vars: dict[str, str],
+    system_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Объединяет переменные из .env и системного окружения.
+
+    Приоритет: system_env > dotenv_vars
+    (системные переменные перезаписывают значения из .env)
+
+    Args:
+        dotenv_vars: Переменные из .env файла
+        system_env: Системные переменные окружения (по умолчанию os.environ)
+
+    Returns:
+        Объединенный словарь переменных
+    """
+    if system_env is None:
+        system_env = dict(os.environ)
+
+    merged = {}
+    merged.update(dotenv_vars)
+    merged.update(system_env)
+
+    return merged
+
+
+def load_env_with_dotenv(
+    dotenv_path: str | Path | bool | None = None,
+    override: bool = False,
+) -> dict[str, str]:
+    """Загружает переменные окружения с поддержкой .env файлов.
+
+    Args:
+        dotenv_path: Путь к .env файлу, True для автопоиска, None для игнора
+        override: Если True, .env перезаписывает системные переменные
+
+    Returns:
+        Словарь переменных окружения
+
+    Example:
+        >>> env = load_env_with_dotenv(".env")
+        >>> env = load_env_with_dotenv(True)  # Автопоиск .env
+        >>> env = load_env_with_dotenv()  # Только os.environ
+    """
+    if dotenv_path is None:
+        return dict(os.environ)
+
+    dotenv_vars = load_dotenv(dotenv_path)
+
+    if override:
+        merged = dict(os.environ)
+        merged.update(dotenv_vars)
+        return merged
+    else:
+        return merge_env_sources(dotenv_vars)

--- a/envschema/schema.py
+++ b/envschema/schema.py
@@ -1,9 +1,10 @@
-import os
+from pathlib import Path
 from typing import Any, get_type_hints
 
 from .casters import cast_value
 from .errors import EnvSchemaError, ValidationError
 from .field import _MISSING, Field, field_from_default
+from .loader import load_env_with_dotenv
 
 
 class EnvSchemaMeta(type):
@@ -105,21 +106,30 @@ class EnvSchema(metaclass=EnvSchemaMeta):
         cls,
         env: dict[str, str] | None = None,
         prefix: str = "",
+        dotenv_path: str | Path | bool | None = None,
+        dotenv_override: bool = False,
     ) -> "EnvSchema":
         """Загружает и валидирует схему из переменных окружения.
 
         Args:
             env: Словарь переменных окружения (по умолчанию os.environ)
             prefix: Префикс для всех переменных схемы
-
-        Returns:
-            Экземпляр схемы со значениями из окружения
+            dotenv_path: Путь к .env файлу, True для автопоиска, None для игнора
+            dotenv_override: Если True, .env перезаписывает системные переменные
 
         Raises:
             EnvSchemaError: Если валидация не прошла
+            ImportError: Если python-dotenv не установлен (if using dotenv_path)
+            FileNotFoundError: Если .env файл не найден
+
+        Example:
+            >>> settings = Settings.load()  # Только os.environ
+            >>> settings = Settings.load(dotenv_path=".env")  # С .env файлом
+            >>> settings = Settings.load(dotenv_path=True)  # Автопоиск .env
         """
         if env is None:
-            env = dict(os.environ)
+            # Загружаем окружение с поддержкой .env файлов
+            env = load_env_with_dotenv(dotenv_path, dotenv_override)
 
         fields = cls._get_fields()
         errors: list[ValidationError] = []

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -20,6 +20,7 @@ def mock_dotenv() -> None:
     """Мокает модуль dotenv для всех тестов."""
     mock_dotenv_module = MagicMock()
     mock_dotenv_module.dotenv_values = MagicMock()
+    mock_dotenv_module.find_dotenv = MagicMock()
 
     with patch.dict("sys.modules", {"dotenv": mock_dotenv_module}):
         yield
@@ -72,18 +73,24 @@ class TestLoadDotenv:
         """Проверяет автопоиск .env файла при dotenv_path=True."""
         env_file = tmp_path / ".env"
         env_file.write_text("AUTO_KEY=auto_value\n")
+        sys.modules["dotenv"].find_dotenv.return_value = str(env_file)
+        sys.modules["dotenv"].dotenv_values.return_value = {"AUTO_KEY": "auto_value"}
 
-        original_cwd = os.getcwd()
-        try:
-            os.chdir(tmp_path)
-            sys.modules["dotenv"].dotenv_values.return_value = {
-                "AUTO_KEY": "auto_value"
-            }
+        result = load_dotenv(True)
+        assert result == {"AUTO_KEY": "auto_value"}
+        sys.modules["dotenv"].find_dotenv.assert_called_once_with(usecwd=True)
 
-            result = load_dotenv(True)
-            assert result == {"AUTO_KEY": "auto_value"}
-        finally:
-            os.chdir(original_cwd)
+    def test_load_dotenv_with_bool_true_not_found(self) -> None:
+        """Проверяет ошибку при автопоиске, если файл не найден."""
+        # Мокаем find_dotenv для возврата пустой строки (файл не найден)
+        sys.modules["dotenv"].find_dotenv.return_value = ""
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            load_dotenv(True)
+
+        assert ".env file not found in current or parent directories" in str(
+            exc_info.value
+        )
 
     def test_load_dotenv_with_bool_false(self) -> None:
         """Проверяет возврат пустого словаря при dotenv_path=False."""
@@ -277,12 +284,11 @@ class TestLoadEnvWithDotenv:
         env_file = tmp_path / ".env"
         env_file.write_text("AUTO_KEY=auto_value\n")
 
-        original_cwd = os.getcwd()
         original_env = dict(os.environ)
 
         try:
             os.environ.clear()
-            os.chdir(tmp_path)
+            sys.modules["dotenv"].find_dotenv.return_value = str(env_file)
             sys.modules["dotenv"].dotenv_values.return_value = {
                 "AUTO_KEY": "auto_value"
             }
@@ -290,8 +296,8 @@ class TestLoadEnvWithDotenv:
             result = load_env_with_dotenv(dotenv_path=True)
 
             assert result["AUTO_KEY"] == "auto_value"
+            sys.modules["dotenv"].find_dotenv.assert_called_once_with(usecwd=True)
         finally:
-            os.chdir(original_cwd)
             os.environ.clear()
             os.environ.update(original_env)
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,353 @@
+"""Тесты для модуля loader.py."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from envschema.loader import (
+    load_dotenv,
+    load_env_with_dotenv,
+    merge_env_sources,
+)
+
+
+@pytest.fixture(autouse=True)
+def mock_dotenv() -> None:
+    """Мокает модуль dotenv для всех тестов."""
+    mock_dotenv_module = MagicMock()
+    mock_dotenv_module.dotenv_values = MagicMock()
+
+    with patch.dict("sys.modules", {"dotenv": mock_dotenv_module}):
+        yield
+
+
+class TestLoadDotenv:
+    """Тесты для функции load_dotenv."""
+
+    def test_load_dotenv_with_string_path(self) -> None:
+        """Проверяет загрузку .env файла по строковому пути."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("KEY1=value1\nKEY2=value2\nKEY3=value3\n")
+            temp_path = f.name
+
+        try:
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "KEY1": "value1",
+                "KEY2": "value2",
+                "KEY3": "value3",
+            }
+
+            result = load_dotenv(temp_path)
+            assert result == {
+                "KEY1": "value1",
+                "KEY2": "value2",
+                "KEY3": "value3",
+            }
+            sys.modules["dotenv"].dotenv_values.assert_called_once_with(temp_path)
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_dotenv_with_path_object(self) -> None:
+        """Проверяет загрузку .env файла по объекту Path."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("TEST_KEY=test_value\n")
+            temp_path = Path(f.name)
+
+        try:
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "TEST_KEY": "test_value"
+            }
+
+            result = load_dotenv(temp_path)
+            assert result == {"TEST_KEY": "test_value"}
+            sys.modules["dotenv"].dotenv_values.assert_called_once_with(str(temp_path))
+        finally:
+            os.unlink(str(temp_path))
+
+    def test_load_dotenv_with_bool_true(self, tmp_path: Path) -> None:
+        """Проверяет автопоиск .env файла при dotenv_path=True."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("AUTO_KEY=auto_value\n")
+
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "AUTO_KEY": "auto_value"
+            }
+
+            result = load_dotenv(True)
+            assert result == {"AUTO_KEY": "auto_value"}
+        finally:
+            os.chdir(original_cwd)
+
+    def test_load_dotenv_with_bool_false(self) -> None:
+        """Проверяет возврат пустого словаря при dotenv_path=False."""
+        result = load_dotenv(False)
+        assert result == {}
+
+    def test_load_dotenv_filters_none_values(self) -> None:
+        """Проверяет фильтрацию None значений из .env файла."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("KEY1=value1\nKEY2=\nKEY3=value3\n")
+            temp_path = f.name
+
+        try:
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "KEY1": "value1",
+                "KEY2": None,
+                "KEY3": "value3",
+            }
+
+            result = load_dotenv(temp_path)
+            assert "KEY1" in result
+            assert "KEY2" not in result
+            assert "KEY3" in result
+            assert result["KEY1"] == "value1"
+            assert result["KEY3"] == "value3"
+        finally:
+            os.unlink(temp_path)
+
+    def test_load_dotenv_file_not_found(self) -> None:
+        """Проверяет ошибку при отсутствии .env файла."""
+        non_existent = Path("/non/existent/path/.env")
+
+        with pytest.raises(FileNotFoundError) as exc_info:
+            load_dotenv(non_existent)
+
+        assert ".env file not found" in str(exc_info.value)
+        assert str(non_existent) in str(exc_info.value)
+
+    def test_load_dotenv_import_error(self) -> None:
+        """Проверяет ошибку при отсутствии python-dotenv."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            temp_path = f.name
+
+        try:
+            # Временно удаляем мок dotenv для этого теста
+            with patch.dict("sys.modules", {"dotenv": None}):
+                with pytest.raises(ImportError) as exc_info:
+                    load_dotenv(temp_path)
+
+                error_msg = str(exc_info.value)
+                assert "python-dotenv is required" in error_msg
+                assert "pip install" in error_msg
+        finally:
+            os.unlink(temp_path)
+
+
+class TestMergeEnvSources:
+    """Тесты для функции merge_env_sources."""
+
+    def test_merge_basic(self) -> None:
+        """Проверяет базовое объединение переменных."""
+        dotenv_vars = {"KEY1": "dotenv_value1", "KEY2": "dotenv_value2"}
+        system_env = {"KEY2": "system_value2", "KEY3": "system_value3"}
+
+        result = merge_env_sources(dotenv_vars, system_env)
+
+        assert result["KEY1"] == "dotenv_value1"
+        assert result["KEY2"] == "system_value2"
+        assert result["KEY3"] == "system_value3"
+
+    def test_merge_system_env_priority(self) -> None:
+        """Проверяет приоритет system_env над dotenv_vars."""
+        dotenv_vars = {"CONFLICT_KEY": "dotenv_value"}
+        system_env = {"CONFLICT_KEY": "system_value"}
+
+        result = merge_env_sources(dotenv_vars, system_env)
+
+        assert result["CONFLICT_KEY"] == "system_value"
+
+    def test_merge_with_none_system_env(self) -> None:
+        """Проверяет использование os.environ при system_env=None."""
+        dotenv_vars = {"DOTENV_KEY": "dotenv_value"}
+
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.environ["SYSTEM_KEY"] = "system_value"
+            os.environ["DOTENV_KEY"] = "system_override"
+
+            result = merge_env_sources(dotenv_vars, None)
+
+            assert result["DOTENV_KEY"] == "system_override"
+            assert result["SYSTEM_KEY"] == "system_value"
+        finally:
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_merge_empty_dotenv(self) -> None:
+        """Проверяет объединение с пустым dotenv_vars."""
+        system_env = {"KEY1": "value1", "KEY2": "value2"}
+
+        result = merge_env_sources({}, system_env)
+
+        assert result == system_env
+
+    def test_merge_empty_system_env(self) -> None:
+        """Проверяет объединение с пустым system_env."""
+        dotenv_vars = {"KEY1": "value1", "KEY2": "value2"}
+
+        result = merge_env_sources(dotenv_vars, {})
+
+        assert result == dotenv_vars
+
+    def test_merge_both_empty(self) -> None:
+        """Проверяет объединение двух пустых словарей."""
+        result = merge_env_sources({}, {})
+
+        assert result == {}
+
+
+class TestLoadEnvWithDotenv:
+    """Тесты для функции load_env_with_dotenv."""
+
+    def test_load_with_none_dotenv_path(self) -> None:
+        """Проверяет загрузку только os.environ при dotenv_path=None."""
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.environ["TEST_KEY"] = "test_value"
+
+            result = load_env_with_dotenv(dotenv_path=None)
+
+            assert "TEST_KEY" in result
+            assert result["TEST_KEY"] == "test_value"
+        finally:
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_with_string_path(self) -> None:
+        """Проверяет загрузку с указанием строкового пути."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("DOTENV_KEY=dotenv_value\n")
+            temp_path = f.name
+
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.environ["SYSTEM_KEY"] = "system_value"
+            os.environ["DOTENV_KEY"] = "system_override"
+
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "DOTENV_KEY": "dotenv_value"
+            }
+
+            result = load_env_with_dotenv(dotenv_path=temp_path, override=False)
+
+            assert result["DOTENV_KEY"] == "system_override"
+            assert result["SYSTEM_KEY"] == "system_value"
+        finally:
+            os.unlink(temp_path)
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_with_path_object(self) -> None:
+        """Проверяет загрузку с указанием объекта Path."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("PATH_KEY=path_value\n")
+            temp_path = Path(f.name)
+
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "PATH_KEY": "path_value"
+            }
+
+            result = load_env_with_dotenv(dotenv_path=temp_path)
+
+            assert result["PATH_KEY"] == "path_value"
+        finally:
+            os.unlink(str(temp_path))
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_with_bool_true(self, tmp_path: Path) -> None:
+        """Проверяет автопоиск .env файла при dotenv_path=True."""
+        env_file = tmp_path / ".env"
+        env_file.write_text("AUTO_KEY=auto_value\n")
+
+        original_cwd = os.getcwd()
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.chdir(tmp_path)
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "AUTO_KEY": "auto_value"
+            }
+
+            result = load_env_with_dotenv(dotenv_path=True)
+
+            assert result["AUTO_KEY"] == "auto_value"
+        finally:
+            os.chdir(original_cwd)
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_with_override_false(self) -> None:
+        """Проверяет режим override=False (system_env имеет приоритет)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("CONFLICT_KEY=dotenv_value\n")
+            temp_path = f.name
+
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.environ["CONFLICT_KEY"] = "system_value"
+
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "CONFLICT_KEY": "dotenv_value"
+            }
+
+            result = load_env_with_dotenv(dotenv_path=temp_path, override=False)
+
+            assert result["CONFLICT_KEY"] == "system_value"
+        finally:
+            os.unlink(temp_path)
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_with_override_true(self) -> None:
+        """Проверяет режим override=True (dotenv перезаписывает system)."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".env", delete=False) as f:
+            f.write("CONFLICT_KEY=dotenv_value\n")
+            temp_path = f.name
+
+        original_env = dict(os.environ)
+
+        try:
+            os.environ.clear()
+            os.environ["CONFLICT_KEY"] = "system_value"
+            os.environ["SYSTEM_ONLY_KEY"] = "system_only"
+
+            sys.modules["dotenv"].dotenv_values.return_value = {
+                "CONFLICT_KEY": "dotenv_value"
+            }
+
+            result = load_env_with_dotenv(dotenv_path=temp_path, override=True)
+
+            assert result["CONFLICT_KEY"] == "dotenv_value"
+            assert result["SYSTEM_ONLY_KEY"] == "system_only"
+        finally:
+            os.unlink(temp_path)
+            os.environ.clear()
+            os.environ.update(original_env)
+
+    def test_load_file_not_found(self) -> None:
+        """Проверяет ошибку при отсутствии .env файла."""
+        non_existent = Path("/non/existent/path/.env")
+
+        with pytest.raises(FileNotFoundError):
+            load_env_with_dotenv(dotenv_path=non_existent)


### PR DESCRIPTION
## Summary

Added optional support for loading environment variables from `.env` files via the `dotenv_path` parameter in the `load()` method. The implementation uses `python-dotenv` as an optional dependency and ensures correct handling of priorities between system environment variables and values from `.env` files.

## Motivation

Fixes #2

Many projects use `.env` files for local development. Previously, users had to manually load `.env` files using third-party libraries before calling `Settings.load()`, which complicated the API and required additional dependencies. This functionality is now built into the library, improving the developer experience and aligning with standard practices in the Python ecosystem (as in Pydantic Settings, django-environ).

## User-facing behavior

- [x] User-facing changes (describe below)

### New API

The `load()` method now supports two new parameters:

```python
# Explicit .env file loading
settings = Settings.load(dotenv_path=".env")

# Auto-discover .env in the current directory
settings = Settings.load(dotenv_path=True)

# .env overrides system environment variables
settings = Settings.load(dotenv_path=".env", dotenv_override=True)

# Only os.environ (default behavior)
settings = Settings.load()  # or dotenv_path=None
```

### Variable Priority

By default (`dotenv_override=False`):
- System environment variables (`os.environ`) take priority over values from `.env`
- This aligns with standard practices and ensures security in production

With `dotenv_override=True`:
- Values from `.env` override system environment variables
- Useful for local development

### Error Handling

- If `python-dotenv` is not installed and `dotenv_path` is used, a clear `ImportError` is raised with installation instructions
- If the specified `.env` file is not found, a `FileNotFoundError` is raised with the path specified

## Implementation details

### New Modules and Functions

**`envschema/loader.py`** - new module with three functions:

1. **`load_dotenv(dotenv_path)`** - loads variables from a `.env` file
   - Supports string paths, `Path` objects, and boolean values (`True` for auto-discovery, `False` for empty result)
   - Filters `None` values from the `dotenv_values()` result
   - Raises clear errors when the library or file is missing

2. **`merge_env_sources(dotenv_vars, system_env)`** - merges variables from different sources
   - Uses `os.environ` by default if `system_env=None`
   - Priority: `system_env > dotenv_vars`

3. **`load_env_with_dotenv(dotenv_path, override)`** - main function for loading environment
   - If `dotenv_path=None`, returns only `os.environ`
   - Supports `override` mode for changing priority

### Changes in `envschema/schema.py`

- The `load()` method is extended with `dotenv_path` and `dotenv_override` parameters
- When `env=None`, `load_env_with_dotenv()` is used to load the environment
- Backward compatibility is maintained: if `env` is explicitly passed, `.env` files are ignored

### Optional Dependency

- `python-dotenv` is not a required dependency
- Import is performed inside the function with `ImportError` handling
- Added `# type: ignore[import-not-found]` for correct mypy operation

### Edge Cases

- The `.env` path can be a string, `Path` object, `True` (auto-discovery), `False` (empty result), or `None` (ignore)
- Filtering of `None` values from `.env` file (empty values are ignored)
- Correct handling of missing file or library

## Tests

- [x] Added/updated unit tests

### Test notes

Added a complete test suite in `tests/test_loader.py`:

**`TestLoadDotenv`** (7 tests):
- Loading by string path
- Loading by `Path` object
- Auto-discovery with `dotenv_path=True`
- Returning empty dictionary with `dotenv_path=False`
- Filtering `None` values
- Error when file is missing
- Error when `python-dotenv` is missing

**`TestMergeEnvSources`** (6 tests):
- Basic variable merging
- Priority of `system_env` over `dotenv_vars`
- Using `os.environ` by default
- Working with empty dictionaries

**`TestLoadEnvWithDotenv`** (7 tests):
- Loading only `os.environ` with `dotenv_path=None`
- Loading with different path types
- `override=True/False` modes
- Error when file is missing

All tests use mocking of `dotenv.dotenv_values` to be independent of `python-dotenv` installation.

### Testing Examples

```env
# .env file for tests
KEY1=value1
KEY2=value2
KEY3=value3
```

```python
# Test variable priority
os.environ["KEY1"] = "system_value"
settings = Settings.load(dotenv_path=".env")
assert settings.key1 == "system_value"  # system has priority
```

## Backward compatibility

- [x] No breaking changes

All changes are fully backward compatible:
- The `load()` method works as before by default (only `os.environ`)
- New parameters are optional and have default values
- If `env` is explicitly passed, behavior does not change
- Existing code will continue to work without modifications

## Checklist

- [x] Follows `envschema` scope (no heavy validation framework features)
- [x] Public API is documented (README / docstrings)
- [x] Errors are clear and aggregated where applicable
- [x] Type hints added/updated
- [x] Code is DRY and functions stay reasonably small

### Additional Details

- All functions in `loader.py` have complete Google Style docstrings
- All functions do not exceed 80 lines (compliance with project rules)
- Code follows DRY and SOLID principles
- Type hints added for all parameters and return values
- Errors contain clear messages with instructions
