### PR TITLE
PyPi files and fix link in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Type-safe environment variables with automatic validation and documentation generation**
 
-[Documentation](#documentation) | [Installation](#installation) | [Quick Start](#quick-start) | [Examples](#examples) | [Читать на русском](README_RU.md)
+[Documentation](#documentation) | [Installation](#installation) | [Quick Start](#quick-start) | [Examples](#examples) | [Читать на русском](README_ru.md)
 
 </div>
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[egg_info]
+tag_build = 
+tag_date = 0

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+
+import builtins
+
+from setuptools import setup
+
+version = "1.0.0"
+
+with builtins.open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="envschema",
+    version=version,
+    author="AzaZLO",
+    author_email="maloymeee@yandex.ru",
+    description=(
+        "Type-safe environment variables with automatic validation "
+        "and documentation generation"
+    ),
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/g7AzaZLO/envschema",
+    download_url=f"https://github.com/g7AzaZLO/envschema/archive/v{version}.zip",
+    license="Apache License 2.0",
+    packages=["envschema"],
+    install_requires=[
+        "python-dotenv>=1.0.0",
+    ],
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
+    ],
+)


### PR DESCRIPTION
## Summary
Fixed the link to Russian documentation in README and added PyPI packaging configuration.

## Motivation
- Fixed the link to Russian documentation for better navigation
- Prepared the package for PyPI publication with proper metadata configuration

## User-facing behavior
- [x] User-facing changes (describe below)
  - Fixed the link to Russian documentation in README.md
  - Package is ready for PyPI publication with proper description rendering

## Implementation details
- **README.md**: Fixed the link to `README_ru.md` in navigation
- **setup.py**: 
  - Added `long_description_content_type="text/markdown"` for proper Markdown rendering on PyPI
  - Added `url` and `download_url` with links to GitHub repository
  - Added PyPI classifiers (Intended Audience, License, OS Independent, Python versions)
- **setup.cfg**: Configured package build settings

## Tests
- [x] Manual testing
  - Verified correctness of links in README
  - Tested package build with `python setup.py sdist`
  - Verified PyPI metadata correctness

### Test notes
# Build verification:
python setup.py sdist

# Content verification:
# - README.md renders correctly on PyPI
# - Documentation links work properly## Backward compatibility
- [x] No breaking changes
  - All changes are metadata and documentation only, no API changes

## Checklist
- [x] Follows `envschema` scope (no heavy validation framework features)
- [x] Public API is documented (README / docstrings)
- [x] Errors are clear and aggregated where applicable
- [x] Type hints added/updated
- [x] Code is DRY and functions stay reasonably small